### PR TITLE
Fix: Both Node 4 and 6 are active LTS at the moment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ nodeAbi.allTargets
 // [
 //  { runtime: 'node', target: '0.10.48', lts: false },
 //  { runtime: 'node', target: '0.12.17', lts: false },
-//  { runtime: 'node', target: '4.6.1', lts: false },
+//  { runtime: 'node', target: '4.6.1', lts: true },
 //  { runtime: 'node', target: '5.12.0', lts: false },
 //  { runtime: 'node', target: '6.9.4', lts: true },
 //  { runtime: 'node', target: '7.4.0', lts: false },
@@ -38,3 +38,4 @@ nodeAbi.allTargets
 
 - https://github.com/lgeiger/electron-abi
 - https://nodejs.org/en/download/releases/
+- https://github.com/nodejs/LTS

--- a/index.js
+++ b/index.js
@@ -44,9 +44,9 @@ function getAbi (target, runtime) {
 var allTargets = [
   {runtime: 'node', target: '0.10.48', lts: false},
   {runtime: 'node', target: '0.12.17', lts: false},
-  {runtime: 'node', target: '4.6.1', lts: false},
+  {runtime: 'node', target: '4.6.1', lts: new Date() < new Date(2017, 04, 01)},
   {runtime: 'node', target: '5.12.0', lts: false},
-  {runtime: 'node', target: '6.9.4', lts: true},
+  {runtime: 'node', target: '6.9.4', lts: new Date() < new Date(2018, 04, 18)},
   {runtime: 'node', target: '7.4.0', lts: false},
   {runtime: 'electron', target: '1.0.2', lts: false},
   {runtime: 'electron', target: '1.2.8', lts: false},


### PR DESCRIPTION
Fix https://github.com/lgeiger/node-abi/pull/3#discussion_r97977698

Reference: https://github.com/nodejs/LTS