### PR TITLE
Provide a slightly more user friendly error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function getAbi (target, runtime) {
     if (/^0\.[2-8]/.test(target)) return '1'
   }
 
-  throw new Error('Could not detect abi for version ' + target + ' and runtime ' + runtime)
+  throw new Error('Could not detect abi for version ' + target + ' and runtime ' + runtime + '.  Updating "node-abi" might help solve this issue if it is a new release of ' + runtime)
 }
 
 function getTarget (abi, runtime) {


### PR DESCRIPTION
We use this module in `electron-rebuild` and some people hit the issue recently where Electron `1.6` came out and their existing install threw an error saying it failing to map the ABI version.  This message will help users more rapidly identify a potential solution to this issue. 👍 