### PR TITLE
Use semantic release to automate the release process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,24 @@
-sudo: false
-os: linux
 language: node_js
+notifications:
+  email: false
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4"
-  - "5"
-  - "6"
-  - "7"
+  - '8'
+  - '6'
+  - '4'
+  - '0.12'
+  - '0.10'
 matrix:
   include:
-    - node_js: "6"
+    - node_js: "8"
       env: TEST_SUITE=lint
 env:
   - TEST_SUITE=unit
-script: npm run-script $TEST_SUITE
+before_script:
+  - npm prune
+script:
+  - npm run-script $TEST_SUITE
+after_success:
+  - npm run semantic-release
+branches:
+  except:
+    - /^v\d+\.\d+\.\d+$/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at lukas.geiger94@gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct/
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing to `node-abi`
+
+:+1::tada: First off, thanks for taking the time to contribute to `node-abi`! :tada::+1:
+
+## Commit Message Guidelines
+
+This module uses [`semantic-release`](https://github.com/semantic-release/semantic-release) to automatically release new versions via Travis.
+Therefor we have very precise rules over how our git commit messages can be formatted.
+
+Each commit message consists of a **header**, a **body** and a **footer**.  The header has a special
+format that includes a **type**, a **scope** and a **subject** ([full explanation](https://github.com/stevemao/conventional-changelog-angular/blob/master/convention.md)):
+
+```
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+### Type
+
+Must be one of the following:
+
+- **feat**: A new feature. **Will trigger a new release**
+- **fix**: A bug fix or a addition to one of the target arrays. **Will trigger a new release**
+- **docs**: Documentation only changes
+- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+- **refactor**: A code change that neither fixes a bug nor adds a feature
+- **perf**: A code change that improves performance
+- **test**: Adding missing or correcting existing tests
+- **chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation
+
+
+### Patch Release
+
+```
+fix(electron): Support Electron 1.8.0
+```
+
+### ~~Minor~~ Feature Release
+
+```
+feat: add .getTarget(abi, runtime)
+```
+
+### ~~Major~~ Breaking Release
+
+```
+feat: Add amazing new feature
+
+BREAKING CHANGE: This removes support for Node 0.10 and 0.12.
+```

--- a/package.json
+++ b/package.json
@@ -1,16 +1,17 @@
 {
   "name": "node-abi",
-  "version": "2.1.1",
+  "version": "0.0.0-development",
   "description": "Get the Node ABI for a given target and runtime, and vice versa.",
   "main": "index.js",
   "scripts": {
     "lint": "standard",
     "test": "npm run lint && npm run unit",
-    "unit": "tape test/index.js"
+    "unit": "tape test/index.js",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/lgeiger/node-abi.git"
+    "url": "https://github.com/lgeiger/node-abi.git"
   },
   "keywords": [
     "node",
@@ -27,7 +28,8 @@
   "homepage": "https://github.com/lgeiger/node-abi#readme",
   "devDependencies": {
     "standard": "^10.0.0",
-    "tape": "^4.6.3"
+    "tape": "^4.6.3",
+    "semantic-release": "^7.0.2"
   },
   "dependencies": {
     "semver": "^5.4.1"


### PR DESCRIPTION
With this in place [`semantice-release`](https://github.com/semantic-release/semantic-release) will automatically release new versions on Travis. This will allow us to ship a lot quicker when new versions of Electron or Node are released.

It will determine the version depending on the git commit messages. How to properly format the messages is described in the [new contributing guide](https://github.com/lgeiger/node-abi/blob/57680f29ffe0dd4df2dc2145cd95d170bdec8f9d/CONTRIBUTING.md).