### PR TITLE
Add support to node-webkit target.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ nodeAbi.allTargets
 // ]
 nodeAbi.deprecatedTargets
 nodeAbi.supportedTargets
+nodeAbi.additionalTargets
 nodeAbi.futureTargets
 // ...
 ```

--- a/index.js
+++ b/index.js
@@ -62,7 +62,10 @@ var supportedTargets = [
   {runtime: 'electron', target: '1.5.0', abi: '51', lts: false},
   {runtime: 'electron', target: '1.6.0', abi: '53', lts: false},
   {runtime: 'electron', target: '1.7.0', abi: '54', lts: false},
-  {runtime: 'electron', target: '1.8.0', abi: '57', lts: false},
+  {runtime: 'electron', target: '1.8.0', abi: '57', lts: false}
+]
+
+var additionalTargets = [
   {runtime: 'node-webkit', target: '0.13.0', abi: '47', lts: false},
   {runtime: 'node-webkit', target: '0.15.0', abi: '48', lts: false},
   {runtime: 'node-webkit', target: '0.18.3', abi: '51', lts: false},
@@ -89,12 +92,16 @@ var deprecatedTargets = [
 
 var futureTargets = []
 
-var allTargets = deprecatedTargets.concat(supportedTargets).concat(futureTargets)
+var allTargets = deprecatedTargets
+      .concat(supportedTargets)
+      .concat(additionalTargets)
+      .concat(futureTargets)
 
 exports.getAbi = getAbi
 exports.getTarget = getTarget
 exports.deprecatedTargets = deprecatedTargets
 exports.supportedTargets = supportedTargets
+exports.additionalTargets = additionalTargets
 exports.futureTargets = futureTargets
 exports.allTargets = allTargets
 exports._getNextTarget = getNextTarget

--- a/index.js
+++ b/index.js
@@ -62,7 +62,12 @@ var supportedTargets = [
   {runtime: 'electron', target: '1.5.0', abi: '51', lts: false},
   {runtime: 'electron', target: '1.6.0', abi: '53', lts: false},
   {runtime: 'electron', target: '1.7.0', abi: '54', lts: false},
-  {runtime: 'electron', target: '1.8.0', abi: '57', lts: false}
+  {runtime: 'electron', target: '1.8.0', abi: '57', lts: false},
+  {runtime: 'node-webkit', target: '0.13.0', abi: '47', lts: false},
+  {runtime: 'node-webkit', target: '0.15.0', abi: '48', lts: false},
+  {runtime: 'node-webkit', target: '0.18.3', abi: '51', lts: false},
+  {runtime: 'node-webkit', target: '0.23.0', abi: '57', lts: false},
+  {runtime: 'node-webkit', target: '0.26.5', abi: '59', lts: false}
 ]
 
 var deprecatedTargets = [

--- a/test/index.js
+++ b/test/index.js
@@ -139,11 +139,13 @@ test('getAbi returns abi if passed as target', function (t) {
 test('allTargets are sorted', function (t) {
   var electron = allTargets.filter(function (t) { return t.runtime === 'electron' })
   var node = allTargets.filter(function (t) { return t.runtime === 'node' })
+  var nodeWebkit = allTargets.filter(function (t) { return t.runtime === 'node-webkit' })
   function sort (t1, t2) {
     return semver.compare(t1.target, t2.target)
   }
 
   t.deepEqual(electron, electron.slice().sort(sort))
   t.deepEqual(node, node.slice().sort(sort))
+  t.deepEqual(nodeWebkit, nodeWebkit.slice().sort(sort))
   t.end()
 })

--- a/test/index.js
+++ b/test/index.js
@@ -38,6 +38,16 @@ test('getTarget calculates correct Electron target', function (t) {
   t.end()
 })
 
+test('getTarget calculates correct Node-Webkit target', function (t) {
+  t.throws(getTarget.bind(null, '14', 'ode-webkit'))
+  t.equal(getTarget('47', 'node-webkit'), '0.13.0')
+  t.equal(getTarget('48', 'node-webkit'), '0.15.0')
+  t.equal(getTarget('51', 'node-webkit'), '0.18.3')
+  t.equal(getTarget('57', 'node-webkit'), '0.23.0')
+  t.equal(getTarget('59', 'node-webkit'), '0.26.5')
+  t.end()
+})
+
 test('getAbi calculates correct Node ABI', function (t) {
   t.equal(getAbi(undefined), process.versions.modules)
   t.equal(getAbi(null), process.versions.modules)
@@ -91,6 +101,28 @@ test('getAbi calculates correct Electron ABI', function (t) {
   t.equal(getAbi('0.32.0', 'electron'), '45')
   t.equal(getAbi('0.31.0', 'electron'), '45')
   t.equal(getAbi('0.30.0', 'electron'), '44')
+  t.end()
+})
+
+test('getAbi calculates correct Node-Webkit ABI', function (t) {
+  t.throws(function () { getAbi(undefined, 'node-webkit') })
+  t.throws(function () { getAbi(getNextTarget('node-webkit'), 'node-webkit') })
+  t.equal(getAbi('0.13.0', 'node-webkit'), '47')
+  t.equal(getAbi('0.14.0', 'node-webkit'), '47')
+  t.equal(getAbi('0.15.0', 'node-webkit'), '48')
+  t.equal(getAbi('0.16.0', 'node-webkit'), '48')
+  t.equal(getAbi('0.17.0', 'node-webkit'), '48')
+  t.equal(getAbi('0.18.2', 'node-webkit'), '48')
+  t.equal(getAbi('0.18.3', 'node-webkit'), '51')
+  t.equal(getAbi('0.19.0', 'node-webkit'), '51')
+  t.equal(getAbi('0.20.0', 'node-webkit'), '51')
+  t.equal(getAbi('0.21.0', 'node-webkit'), '51')
+  t.equal(getAbi('0.22.0', 'node-webkit'), '51')
+  t.equal(getAbi('0.23.0', 'node-webkit'), '57')
+  t.equal(getAbi('0.24.0', 'node-webkit'), '57')
+  t.equal(getAbi('0.25.0', 'node-webkit'), '57')
+  t.equal(getAbi('0.26.4', 'node-webkit'), '57')
+  t.equal(getAbi('0.26.5', 'node-webkit'), '59')
   t.end()
 })
 


### PR DESCRIPTION
This PR adds support to node-webkit target, necessary to build native modules when using NW.js, an Electron alternative.

Tests are included.

NW.js apparently does not follow a specific versioning pattern to switch ABI, so the `getNextTarget` function can't be implemented correctly for `node-webkit`, so I left it untouched.