### PR TITLE
fix(electron): move Electron 2.0 to the supported list

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,8 @@ var supportedTargets = [
   {runtime: 'electron', target: '1.5.0', abi: '51', lts: false},
   {runtime: 'electron', target: '1.6.0', abi: '53', lts: false},
   {runtime: 'electron', target: '1.7.0', abi: '54', lts: false},
-  {runtime: 'electron', target: '1.8.0', abi: '57', lts: false}
+  {runtime: 'electron', target: '1.8.0', abi: '57', lts: false},
+  {runtime: 'electron', target: '2.0.0', abi: '57', lts: false}
 ]
 
 var additionalTargets = [
@@ -92,7 +93,6 @@ var deprecatedTargets = [
 ]
 
 var futureTargets = [
-  {runtime: 'electron', target: '2.0.0', abi: '57', lts: false}
 ]
 
 var allTargets = deprecatedTargets


### PR DESCRIPTION
[Electron 2.0.0](https://github.com/electron/electron/releases/tag/v2.0.0) was released this week.