### PR TITLE
fix: Move Node 4 to deprecated targets and update LTS schedule

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,13 +49,12 @@ function getTarget (abi, runtime) {
 }
 
 var supportedTargets = [
-  {runtime: 'node', target: '4.0.0', abi: '46', lts: false},
   {runtime: 'node', target: '5.0.0', abi: '47', lts: false},
-  {runtime: 'node', target: '6.0.0', abi: '48', lts: new Date() < new Date(2018, 4, 18)},
+  {runtime: 'node', target: '6.0.0', abi: '48', lts: false},
   {runtime: 'node', target: '7.0.0', abi: '51', lts: false},
-  {runtime: 'node', target: '8.0.0', abi: '57', lts: false},
-  {runtime: 'node', target: '9.0.0', abi: '59', lts: new Date() < new Date(2019, 12, 31)},
-  {runtime: 'node', target: '10.0.0', abi: '64', lts: false},
+  {runtime: 'node', target: '8.0.0', abi: '57', lts: new Date() < new Date(2019, 4, 31)},
+  {runtime: 'node', target: '9.0.0', abi: '59', lts: false},
+  {runtime: 'node', target: '10.0.0', abi: '64', lts: new Date(2018, 10, 1) < new Date() < new Date(2020, 4, 31)},
   {runtime: 'electron', target: '0.36.0', abi: '47', lts: false},
   {runtime: 'electron', target: '1.1.0', abi: '48', lts: false},
   {runtime: 'electron', target: '1.3.0', abi: '49', lts: false},
@@ -87,6 +86,7 @@ var deprecatedTargets = [
   {runtime: 'node', target: '1.1.0', abi: '43', lts: false},
   {runtime: 'node', target: '2.0.0', abi: '44', lts: false},
   {runtime: 'node', target: '3.0.0', abi: '45', lts: false},
+  {runtime: 'node', target: '4.0.0', abi: '46', lts: false},
   {runtime: 'electron', target: '0.30.0', abi: '44', lts: false},
   {runtime: 'electron', target: '0.31.0', abi: '45', lts: false},
   {runtime: 'electron', target: '0.33.0', abi: '46', lts: false}


### PR DESCRIPTION
Version 5.0 of `prebuild-install` dropped support for Node 4 so it doesn't make sense to include it in `supportedTargets` since we use this list to determine for wich distributions to build.

This commit also updates the LTS schedule.

/cc @ralphtheninja @mafintosh @juliangruber 