### PR TITLE
Add electron 4.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,8 @@ var supportedTargets = [
   {runtime: 'electron', target: '1.7.0', abi: '54', lts: false},
   {runtime: 'electron', target: '1.8.0', abi: '57', lts: false},
   {runtime: 'electron', target: '2.0.0', abi: '57', lts: false},
-  {runtime: 'electron', target: '3.0.0', abi: '64', lts: false}
+  {runtime: 'electron', target: '3.0.0', abi: '64', lts: false},
+  {runtime: 'electron', target: '4.0.0', abi: '64', lts: false}
 ]
 
 var additionalTargets = [
@@ -95,7 +96,6 @@ var deprecatedTargets = [
 ]
 
 var futureTargets = [
-  {runtime: 'electron', target: '4.0.0-beta.0', abi: '64', lts: false}
 ]
 
 var allTargets = deprecatedTargets


### PR DESCRIPTION
closes #52 

[electron@4.0.0](https://github.com/electron/electron/releases/tag/v4.0.0) is out.