### PR TITLE
Fix Electron 3 ABI

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ var supportedTargets = [
   {runtime: 'electron', target: '1.7.0', abi: '54', lts: false},
   {runtime: 'electron', target: '1.8.0', abi: '57', lts: false},
   {runtime: 'electron', target: '2.0.0', abi: '57', lts: false},
-  {runtime: 'electron', target: '3.0.0', abi: '64', lts: false},
+  {runtime: 'electron', target: '3.0.0', abi: '59', lts: false},
   {runtime: 'electron', target: '4.0.0', abi: '64', lts: false}
 ]
 


### PR DESCRIPTION
Electron 3's ABI was incorrectly specified as 64 instead of 59, and now that Electron 4 has shipped and actually has ABI version 64, this is causing prebuild/prebuild-install to try to share binaries between Electron 3 and 4 which doesn't work.

Fixes #54