### PR TITLE
fix bug with lts computation for node 10

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ var supportedTargets = [
   {runtime: 'node', target: '7.0.0', abi: '51', lts: false},
   {runtime: 'node', target: '8.0.0', abi: '57', lts: new Date() < new Date(2019, 4, 31)},
   {runtime: 'node', target: '9.0.0', abi: '59', lts: false},
-  {runtime: 'node', target: '10.0.0', abi: '64', lts: new Date(2018, 10, 1) < new Date() < new Date(2020, 4, 31)},
+  {runtime: 'node', target: '10.0.0', abi: '64', lts: new Date(2018, 10, 1) < new Date() && new Date() < new Date(2020, 4, 31)},
   {runtime: 'node', target: '11.0.0', abi: '67', lts: false},
   {runtime: 'electron', target: '0.36.0', abi: '47', lts: false},
   {runtime: 'electron', target: '1.1.0', abi: '48', lts: false},


### PR DESCRIPTION
chained comparisons don't work in node, `a < b < c` is equivalent to `(a < b) < c`, i.e. coerce the boolean `(a < b)` to an integer (0 for false, 1 for true) and then compare that to `c`. So this `lts` test would always have been `true`, since both `0` and `1` are less than `+new Date(2020, 4, 31)`