### PR TITLE
feat: add node v12.0.0 & electron v5.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,10 +52,11 @@ var supportedTargets = [
   {runtime: 'node', target: '5.0.0', abi: '47', lts: false},
   {runtime: 'node', target: '6.0.0', abi: '48', lts: false},
   {runtime: 'node', target: '7.0.0', abi: '51', lts: false},
-  {runtime: 'node', target: '8.0.0', abi: '57', lts: new Date() < new Date(2019, 4, 31)},
+  {runtime: 'node', target: '8.0.0', abi: '57', lts: new Date() < new Date(2019, 12, 31)},
   {runtime: 'node', target: '9.0.0', abi: '59', lts: false},
-  {runtime: 'node', target: '10.0.0', abi: '64', lts: new Date(2018, 10, 1) < new Date() && new Date() < new Date(2020, 4, 31)},
+  {runtime: 'node', target: '10.0.0', abi: '64', lts: new Date() < new Date(2021, 4, 1)},
   {runtime: 'node', target: '11.0.0', abi: '67', lts: false},
+  {runtime: 'node', target: '12.0.0', abi: '72', lts: new Date(2019, 10, 22) <= new Date() && new Date() < new Date(2022, 4, 1)},
   {runtime: 'electron', target: '0.36.0', abi: '47', lts: false},
   {runtime: 'electron', target: '1.1.0', abi: '48', lts: false},
   {runtime: 'electron', target: '1.3.0', abi: '49', lts: false},
@@ -67,7 +68,8 @@ var supportedTargets = [
   {runtime: 'electron', target: '2.0.0', abi: '57', lts: false},
   {runtime: 'electron', target: '3.0.0', abi: '64', lts: false},
   {runtime: 'electron', target: '4.0.0', abi: '64', lts: false},
-  {runtime: 'electron', target: '4.0.4', abi: '69', lts: false}
+  {runtime: 'electron', target: '4.0.4', abi: '69', lts: false},
+  {runtime: 'electron', target: '5.0.0', abi: '72', lts: false}
 ]
 
 var additionalTargets = [
@@ -93,11 +95,11 @@ var deprecatedTargets = [
   {runtime: 'node', target: '4.0.0', abi: '46', lts: false},
   {runtime: 'electron', target: '0.30.0', abi: '44', lts: false},
   {runtime: 'electron', target: '0.31.0', abi: '45', lts: false},
-  {runtime: 'electron', target: '0.33.0', abi: '46', lts: false}
+  {runtime: 'electron', target: '0.33.0', abi: '46', lts: false},
+  {runtime: 'electron', target: '5.0.0-beta.0', abi: '68', lts: false}
 ]
 
 var futureTargets = [
-  {runtime: 'electron', target: '5.0.0-beta.0', abi: '68', lts: false}
 ]
 
 var allTargets = deprecatedTargets


### PR DESCRIPTION
Yesterday Node [v12.0.0](https://nodejs.org/en/blog/release/v12.0.0/) [was released](https://github.com/nodejs/node/releases/tag/v12.0.0) and today Electron v5.0.0 [was released](https://github.com/electron/electron/releases/tag/v5.0.0). I've attempted to update the targets in this project to reflect this.