### PR TITLE
add support for Node 13

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ var supportedTargets = [
   {runtime: 'node', target: '10.0.0', abi: '64', lts: new Date(2018, 10, 1) < new Date() && new Date() < new Date(2020, 4, 31)},
   {runtime: 'node', target: '11.0.0', abi: '67', lts: false},
   {runtime: 'node', target: '12.0.0', abi: '72', lts: false},
+  {runtime: 'node', target: '13.0.0', abi: '79', lts: false},
   {runtime: 'electron', target: '0.36.0', abi: '47', lts: false},
   {runtime: 'electron', target: '1.1.0', abi: '48', lts: false},
   {runtime: 'electron', target: '1.3.0', abi: '49', lts: false},


### PR DESCRIPTION
Node 13 came out last month, with a `NODE_MODULE_VERSION` of `79` based on [the releases list](https://nodejs.org/en/download/releases/):

<img width="1046" src="https://user-images.githubusercontent.com/359239/68763687-6818cd80-05ef-11ea-8a32-bbc8d2d7925a.png">
