### PR TITLE
indicate Node 12 is an LTS release

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ var supportedTargets = [
   {runtime: 'node', target: '9.0.0', abi: '59', lts: false},
   {runtime: 'node', target: '10.0.0', abi: '64', lts: new Date(2018, 10, 1) < new Date() && new Date() < new Date(2020, 4, 31)},
   {runtime: 'node', target: '11.0.0', abi: '67', lts: false},
-  {runtime: 'node', target: '12.0.0', abi: '72', lts: false},
+  {runtime: 'node', target: '12.0.0', abi: '72', lts: new Date(2019, 9, 21) < new Date() && new Date() < new Date(2020, 9, 31)},
   {runtime: 'electron', target: '0.36.0', abi: '47', lts: false},
   {runtime: 'electron', target: '1.1.0', abi: '48', lts: false},
   {runtime: 'electron', target: '1.3.0', abi: '49', lts: false},


### PR DESCRIPTION
https://github.com/nodejs/Release recently marked Node 12 as an active LTS, so I figure I'd flag that in here while I was poking around.

<img width="942" src="https://user-images.githubusercontent.com/359239/68764234-b4184200-05f0-11ea-99ee-45c499ad3086.png">

These should be the bounds specified for the date (converted for convenience):

<img width="420"  src="https://user-images.githubusercontent.com/359239/68764759-add69580-05f1-11ea-9386-8af38061053d.png">

I wasn't quite clear on the rules on what's set for Node 10 as I think that's off by a month, because **the `month` parameter in the `Date` constructor is zero-based** 😱:

<img width="437" src="https://user-images.githubusercontent.com/359239/68764338-e3c74a00-05f0-11ea-8cc1-e6ac8bb67d5b.png">

I think that second date should be `new Date(2020, 3, 31)` (to indicate the end of April), rather than the end of May, but let me know if there's some context I'm missing.


