### PR TITLE
Add electron 10.0.0-beta.1 target

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,9 @@ var deprecatedTargets = [
   {runtime: 'electron', target: '0.33.0', abi: '46', lts: false}
 ]
 
-var futureTargets = []
+var futureTargets = [
+  {runtime: 'electron', target: '10.0.0-beta.1', abi: '82', lts: false}
+]
 
 var allTargets = deprecatedTargets
   .concat(supportedTargets)

--- a/test/index.js
+++ b/test/index.js
@@ -88,6 +88,7 @@ test('getAbi calculates correct Node ABI', function (t) {
 test('getAbi calculates correct Electron ABI', function (t) {
   t.throws(function () { getAbi(undefined, 'electron') })
   t.throws(function () { getAbi(getNextTarget('electron'), 'electron') })
+  t.equal(getAbi('10.0.0-beta.1', 'electron'), '82')
   t.equal(getAbi('9.0.0', 'electron'), '80')
   t.equal(getAbi('8.0.0', 'electron'), '76')
   t.equal(getAbi('7.0.0', 'electron'), '75')


### PR DESCRIPTION
This PR adds electron 10.0.0-beta.1 as a future target so we can build and package apps with this version of electron without a problem.