### PR TITLE
build: fix npm script name used in update API workflow

### DIFF
--- a/.github/workflows/update-abi.yml
+++ b/.github/workflows/update-abi.yml
@@ -22,7 +22,7 @@ jobs:
           ${{ runner.os }}-node-
     - run: npm install
     - name: Update Releases JSON
-      run: npm run electron-releases
+      run: npm run update-abi-registry
     - name: Commit Changes to Releases JSON
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Not sure how this happened, but the npm script name was wrong in the GitHub Action. This fixes it.