### PR TITLE
fix: sorting of targets

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,8 +53,12 @@ function getTarget (abi, runtime) {
   throw new Error('Could not detect target for abi ' + abi + ' and runtime ' + runtime)
 }
 
-function sortByAbiFn (a, b) {
-  return Number(a.abi) - Number(b.abi)
+function sortByTargetFn (a, b) {
+  var abiComp = Number(a.abi) - Number(b.abi)
+  if (abiComp !== 0) return abiComp
+  if (a.target < b.target) return -1
+  if (a.target > b.target) return 1
+  return 0
 }
 
 function loadGeneratedTargets () {
@@ -89,9 +93,9 @@ function loadGeneratedTargets () {
     }
   })
 
-  targets.supported.sort(sortByAbiFn)
-  targets.additional.sort(sortByAbiFn)
-  targets.future.sort(sortByAbiFn)
+  targets.supported.sort(sortByTargetFn)
+  targets.additional.sort(sortByTargetFn)
+  targets.future.sort(sortByTargetFn)
 
   return targets
 }

--- a/index.js
+++ b/index.js
@@ -53,8 +53,8 @@ function getTarget (abi, runtime) {
   throw new Error('Could not detect target for abi ' + abi + ' and runtime ' + runtime)
 }
 
-function sortByTargetFn (a, b) {
-  return Number(a.abi) > Number(b.abi) && a.target > b.target
+function sortByAbiFn (a, b) {
+  return Number(a.abi) - Number(b.abi)
 }
 
 function loadGeneratedTargets () {
@@ -89,9 +89,9 @@ function loadGeneratedTargets () {
     }
   })
 
-  targets.supported.sort(sortByTargetFn)
-  targets.additional.sort(sortByTargetFn)
-  targets.future.sort(sortByTargetFn)
+  targets.supported.sort(sortByAbiFn)
+  targets.additional.sort(sortByAbiFn)
+  targets.future.sort(sortByAbiFn)
 
   return targets
 }


### PR DESCRIPTION
A comparator function for `Array.sort` should return:

- a value less than zero if `a` is less than `b`
- zero if `a` is equal to `b`
- a value greater than zero if `a` is greater than `b`

The previous implementation of the comparator function (introduced in #95) could only ever return true/false, i.e. 1/0 but no -1. So, what I think happened was that when 0 was returned, Node attempted to apply a default ordering on the objects based on the values of all their properties. That is why a seemingly innocuous change such as changing an `lts` property from `false` to `true` resulted in a broken order. I guess the order was previously correct only by accident 😄 