### PR TITLE
ci: don't deploy to auto-updater environment

### DIFF
--- a/.github/workflows/update-abi.yml
+++ b/.github/workflows/update-abi.yml
@@ -16,7 +16,9 @@ jobs:
           - main
           - 3-x-y
     runs-on: ubuntu-latest
-    environment: auto-updater
+    environment:
+      name: auto-updater
+      deployment: false
     permissions:
       id-token: write  # for secret service access
     steps:


### PR DESCRIPTION
We only use this for secret access.

Refs https://github.blog/changelog/2026-03-19-github-actions-late-march-2026-updates/#github-actions-now-allows-developers-to-use-environments-without-auto-deployment